### PR TITLE
rmnet + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,73 @@
+#
+# Normal rules (sorted alphabetically)
+#
+.*
+*.a
+*.bin
+*.bz2
+*.c.[012]*.*
+*.dtb
+*.dtb.S
+*.dwo
+*.elf
+*.gcno
+*.gz
+*.i
+*.ko
+*.ll
+*.lst
+*.lz4
+*.lzma
+*.lzo
+*.mod.c
+*.o
+*.o.*
+*.order
+*.patch
+*.s
+*.so
+*.so.dbg
+*.su
+*.symtypes
+*.tar
+*.xz
+Module.symvers
+modules.builtin
+
+/tags
+/TAGS
+
+/System.map
+/Module.markers
+
+!.gitignore
+!.mailmap
+!.cocciconfig
+
+include/config
+include/generated
+
+# stgit generated dirs
+patches-*
+
+# quilt's files
+patches
+series
+
+# cscope files
+cscope.*
+ncscope.*
+
+# gnu global files
+GPATH
+GRTAGS
+GSYMS
+GTAGS
+
+# id-utils files
+ID
+
+*.orig
+*.rej
+*~
+\#*#

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+obj-y += drivers/rmnet/perf/
+obj-y += drivers/rmnet/shs/

--- a/drivers/rmnet/perf/Kbuild
+++ b/drivers/rmnet/perf/Kbuild
@@ -1,3 +1,3 @@
-obj-m += rmnet_perf.o
+obj-$(CONFIG_RMNET_PERF) += rmnet_perf.o
 rmnet_perf-y := rmnet_perf_config.o rmnet_perf_core.o rmnet_perf_opt.o \
 		rmnet_perf_tcp_opt.o rmnet_perf_udp_opt.o

--- a/drivers/rmnet/perf/Kconfig
+++ b/drivers/rmnet/perf/Kconfig
@@ -4,7 +4,7 @@
 
 menuconfig RMNET_PERF
     tristate "Rmnet Perf driver"
-    default m
-#    depends on RMNET
+    default y
+    depends on RMNET
     ---help---
         performance mode of rmnet driver

--- a/drivers/rmnet/shs/Kbuild
+++ b/drivers/rmnet/shs/Kbuild
@@ -1,2 +1,2 @@
-obj-m += rmnet_shs.o
+obj-$(CONFIG_RMNET_SHS) += rmnet_shs.o
 rmnet_shs-y := rmnet_shs_config.o rmnet_shs_main.o rmnet_shs_wq.o rmnet_shs_freq.o rmnet_shs_wq_mem.o rmnet_shs_wq_genl.o

--- a/drivers/rmnet/shs/Kconfig
+++ b/drivers/rmnet/shs/Kconfig
@@ -4,7 +4,7 @@
 
 menuconfig RMNET_SHS
     tristate "Rmnet SHS driver"
-    default m
-#    depends on RMNET
+    default y
+    depends on RMNET
     ---help---
         performance mode of rmnet driver


### PR DESCRIPTION
Fix rmnet in-tree building and build rmnet only if CONFIG_RMNET is present.

And to ease future development add .gitignore file.