### PR TITLE
[9.12.r1] [DATA-KERNEL] data-kernel: Build rmnet-perf and rmnet-shs for KONA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,7 @@
+ifeq ($(CONFIG_ARCH_KONA), y)
+include $(srctree)/techpack/data-kernel/config/kona.conf
+LINUXINCLUDE	+= -include $(srctree)/techpack/data-kernel/config/konadataconf.h
+endif
+
 obj-y += drivers/rmnet/perf/
 obj-y += drivers/rmnet/shs/

--- a/config/kona.conf
+++ b/config/kona.conf
@@ -1,0 +1,2 @@
+export CONFIG_RMNET_PERF=y
+export CONFIG_RMNET_SHS=y

--- a/config/konadataconf.h
+++ b/config/konadataconf.h
@@ -1,0 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#define CONFIG_RMNET_PERF 1
+#define CONFIG_RMNET_SHS 1


### PR DESCRIPTION
This SoC supports rmnet-shs, enable it to squeeze more battery juice
with SHS offloading and new per-cpu-core flow control.

Compile tested.
Totally sure this works fine anyway.