### PR TITLE
Remove hard-coded `kona` used for comparing with `TARGET_BOARD_PLATFORM`

### DIFF
--- a/data_dlkm_vendor_board.mk
+++ b/data_dlkm_vendor_board.mk
@@ -1,6 +1,5 @@
 #Build rmnet perf & shs
 DATA_DLKM_BOARD_PLATFORMS_LIST := msmnile
-DATA_DLKM_BOARD_PLATFORMS_LIST += kona
 DATA_DLKM_BOARD_PLATFORMS_LIST += lito
 ifneq ($(TARGET_BOARD_AUTO),true)
 ifeq ($(call is-board-platform-in-list,$(DATA_DLKM_BOARD_PLATFORMS_LIST)),true)

--- a/drivers/rmnet/perf/Android.mk
+++ b/drivers/rmnet/perf/Android.mk
@@ -2,7 +2,6 @@ ifneq ($(TARGET_BOARD_AUTO),true)
 ifneq ($(TARGET_PRODUCT),qssi)
 
 RMNET_PERF_DLKM_PLATFORMS_LIST := msmnile
-RMNET_PERF_DLKM_PLATFORMS_LIST += kona
 RMNET_PERF_DLKM_PLATFORMS_LIST += lito
 
 ifeq ($(call is-board-platform-in-list, $(RMNET_PERF_DLKM_PLATFORMS_LIST)),true)
@@ -19,10 +18,6 @@ LOCAL_SRC_FILES += rmnet_perf_tcp_opt.c
 ifeq ($(call is-board-platform-in-list, msmnile),true)
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../../../../../../kernel/msm-4.14/include/
 endif #End of check for msmnile include
-
-ifeq ($(call is-board-platform-in-list, kona),true)
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../../../../../../kernel/msm-4.19/include/
-endif #End of check for kona include
 
 RMNET_PERF_BLD_DIR := ../../vendor/qcom/opensource/data-kernel/drivers/rmnet/perf
 DLKM_DIR := ./device/qcom/common/dlkm

--- a/drivers/rmnet/shs/Android.mk
+++ b/drivers/rmnet/shs/Android.mk
@@ -1,6 +1,5 @@
 ifneq ($(TARGET_PRODUCT),qssi)
 RMNET_SHS_DLKM_PLATFORMS_LIST := msmnile
-RMNET_SHS_DLKM_PLATFORMS_LIST += kona
 RMNET_SHS_DLKM_PLATFORMS_LIST += lito
 
 ifeq ($(call is-board-platform-in-list, $(RMNET_SHS_DLKM_PLATFORMS_LIST)),true)


### PR DESCRIPTION
Some custom ROM (i.e. lineage os) use `KONA := kona`, which would result in these branch statements giving unexpected results.

This PR removes all hard-coded `kona` used for detecting the `TARGET_BOARD_PLATFORM` and hence preserves the behavior even if `KONA := kona` and `TARGET_BOARD_PLATFORM := $(KONA)`.

Compile tested.