### PR TITLE
Remove hard coded msmnile detecting target board.

### DIFF
--- a/data_dlkm_vendor_board.mk
+++ b/data_dlkm_vendor_board.mk
@@ -1,5 +1,4 @@
 #Build rmnet perf & shs
-DATA_DLKM_BOARD_PLATFORMS_LIST := msmnile
 DATA_DLKM_BOARD_PLATFORMS_LIST += lito
 ifneq ($(TARGET_BOARD_AUTO),true)
 ifeq ($(call is-board-platform-in-list,$(DATA_DLKM_BOARD_PLATFORMS_LIST)),true)

--- a/drivers/rmnet/perf/Android.mk
+++ b/drivers/rmnet/perf/Android.mk
@@ -1,7 +1,6 @@
 ifneq ($(TARGET_BOARD_AUTO),true)
 ifneq ($(TARGET_PRODUCT),qssi)
 
-RMNET_PERF_DLKM_PLATFORMS_LIST := msmnile
 RMNET_PERF_DLKM_PLATFORMS_LIST += lito
 
 ifeq ($(call is-board-platform-in-list, $(RMNET_PERF_DLKM_PLATFORMS_LIST)),true)
@@ -14,10 +13,6 @@ LOCAL_MODULE := rmnet_perf.ko
 LOCAL_SRC_FILES := rmnet_perf_config.c
 LOCAL_SRC_FILES += rmnet_perf_core.c
 LOCAL_SRC_FILES += rmnet_perf_tcp_opt.c
-
-ifeq ($(call is-board-platform-in-list, msmnile),true)
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../../../../../../kernel/msm-4.14/include/
-endif #End of check for msmnile include
 
 RMNET_PERF_BLD_DIR := ../../vendor/qcom/opensource/data-kernel/drivers/rmnet/perf
 DLKM_DIR := ./device/qcom/common/dlkm

--- a/drivers/rmnet/shs/Android.mk
+++ b/drivers/rmnet/shs/Android.mk
@@ -1,5 +1,4 @@
 ifneq ($(TARGET_PRODUCT),qssi)
-RMNET_SHS_DLKM_PLATFORMS_LIST := msmnile
 RMNET_SHS_DLKM_PLATFORMS_LIST += lito
 
 ifeq ($(call is-board-platform-in-list, $(RMNET_SHS_DLKM_PLATFORMS_LIST)),true)


### PR DESCRIPTION
Referenced #6.

This change needs for msmnile, too.

Build passed on LineageOS tree.